### PR TITLE
ci: bump actions/setup-go from v5 to v6

### DIFF
--- a/.github/actions/setup-go-env/action.yml
+++ b/.github/actions/setup-go-env/action.yml
@@ -22,7 +22,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version != '' && inputs.go-version || 'stable' }}
         go-version-file: ${{ inputs.go-version == '' && 'go.mod' || '' }}


### PR DESCRIPTION
## Summary
- `actions/setup-go@v5` runs on Node.js 20, which GitHub is deprecating for Actions runtimes.
- Bumps `.github/actions/setup-go-env/action.yml` to `@v6` (Node.js 24), matching the version already in use in `security.yml`.
- Verified other third-party actions (`docker/setup-buildx-action@v4`, `docker/build-push-action@v7`, `goreleaser/goreleaser-action@v7`) already run on node24; `extractions/setup-just@v3` is a composite action with no Node runtime.

## Test plan
- [ ] CI workflow runs green on this PR (exercises the composite action end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)