### PR TITLE
Fix clone-apply progress, timeout, and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Plonk works without configuration. If needed, create `~/.config/plonk/plonk.yaml
 git:
   auto_commit: true                  # Auto-commit after mutations (default: true)
 diff_tool: delta                     # Custom diff viewer
-package_timeout: 300                 # Seconds (default: 180)
+operation_timeout: 600               # Seconds (default: 300)
 ignore_patterns:
   - "*.swp"
   - ".DS_Store"

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -212,9 +212,9 @@ git:
 default_manager: brew
 
 # Timeouts (seconds)
-package_timeout: 180       # Package installation
 operation_timeout: 300     # General operations
 dotfile_timeout: 60        # File operations
+# Note: package installs use a fixed 10-minute per-package timeout.
 
 # Diff tool for viewing drifted files
 diff_tool: delta           # Default: git diff --no-index

--- a/internal/clone/setup.go
+++ b/internal/clone/setup.go
@@ -148,6 +148,8 @@ func SetupFromClonedRepo(ctx context.Context, plonkDir string, hasConfig bool) e
 			orchestrator.WithDryRun(false),
 		)
 		result, err := orch.Apply(ctx)
+		result.Scope = "all"
+		output.RenderOutput(result)
 		if err != nil {
 			hasDotfileErrors := len(result.DotfileErrors) > 0
 			hasOnlyPackageErrors := len(result.PackageErrors) > 0 && !hasDotfileErrors
@@ -185,11 +187,10 @@ default_manager: %s
 
 # Timeout settings (in seconds)
 operation_timeout: %d
-package_timeout: %d
 dotfile_timeout: %d
 
 # Directories to expand when listing dotfiles
-expand_directories:`, defaults.DefaultManager, defaults.OperationTimeout, defaults.PackageTimeout, defaults.DotfileTimeout)
+expand_directories:`, defaults.DefaultManager, defaults.OperationTimeout, defaults.DotfileTimeout)
 
 	// Add expand directories
 	for _, dir := range defaults.ExpandDirectories {

--- a/internal/commands/config_edit_test.go
+++ b/internal/commands/config_edit_test.go
@@ -115,7 +115,6 @@ func TestConfigEditRoundTripPreservesTopLevelFields(t *testing.T) {
 	configContent := `
 default_manager: cargo
 operation_timeout: 600
-package_timeout: 200
 dotfile_timeout: 90
 expand_directories:
   - ".config"
@@ -145,7 +144,6 @@ ignore_patterns:
 
 	assert.Equal(t, originalCfg.DefaultManager, reloadedCfg.DefaultManager)
 	assert.Equal(t, originalCfg.OperationTimeout, reloadedCfg.OperationTimeout)
-	assert.Equal(t, originalCfg.PackageTimeout, reloadedCfg.PackageTimeout)
 	assert.Equal(t, originalCfg.DotfileTimeout, reloadedCfg.DotfileTimeout)
 	assert.Equal(t, originalCfg.ExpandDirectories, reloadedCfg.ExpandDirectories)
 	assert.Equal(t, originalCfg.IgnorePatterns, reloadedCfg.IgnorePatterns)

--- a/internal/commands/zero_config_test.go
+++ b/internal/commands/zero_config_test.go
@@ -34,7 +34,7 @@ func TestConfigResolutionInCommands(t *testing.T) {
 	t.Run("config with partial overrides resolves correctly", func(t *testing.T) {
 		configContent := `default_manager: cargo
 operation_timeout: 900
-# Note: package_timeout and dotfile_timeout not specified - should use defaults
+# Note: dotfile_timeout not specified - should use the default
 `
 		tmpDir := testutil.NewTestConfig(t, configContent)
 
@@ -54,10 +54,6 @@ operation_timeout: 900
 		}
 
 		// Check default values for unspecified settings
-		if cfg.PackageTimeout != 180 {
-			t.Errorf("Expected default package timeout 180, got %d", cfg.PackageTimeout)
-		}
-
 		if cfg.DotfileTimeout != 60 {
 			t.Errorf("Expected default dotfile timeout 60, got %d", cfg.DotfileTimeout)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,6 @@ type GitConfig struct {
 type Config struct {
 	DefaultManager    string                   `yaml:"default_manager,omitempty" validate:"omitempty,validmanager"`
 	OperationTimeout  int                      `yaml:"operation_timeout,omitempty" validate:"omitempty,min=0,max=3600"`
-	PackageTimeout    int                      `yaml:"package_timeout,omitempty" validate:"omitempty,min=0,max=1800"`
 	DotfileTimeout    int                      `yaml:"dotfile_timeout,omitempty" validate:"omitempty,min=0,max=600"`
 	ExpandDirectories []string                 `yaml:"expand_directories,omitempty"`
 	IgnorePatterns    []string                 `yaml:"ignore_patterns,omitempty"`
@@ -56,7 +55,6 @@ type Dotfiles struct {
 var defaultConfig = Config{
 	DefaultManager:   "brew",
 	OperationTimeout: 300, // 5 minutes
-	PackageTimeout:   180, // 3 minutes
 	DotfileTimeout:   60,  // 1 minute
 	ExpandDirectories: []string{
 		".config",
@@ -239,9 +237,6 @@ func ApplyDefaults(cfg *Config) {
 	}
 	if cfg.OperationTimeout == 0 {
 		cfg.OperationTimeout = defaultConfig.OperationTimeout
-	}
-	if cfg.PackageTimeout == 0 {
-		cfg.PackageTimeout = defaultConfig.PackageTimeout
 	}
 	if cfg.DotfileTimeout == 0 {
 		cfg.DotfileTimeout = defaultConfig.DotfileTimeout

--- a/internal/config/config_compat_test.go
+++ b/internal/config/config_compat_test.go
@@ -29,6 +29,8 @@ default_manager: brew
 			},
 		},
 		{
+			// package_timeout is a legacy field (now ignored) — kept here to verify
+			// configs from older plonk versions still load cleanly.
 			name: "config with all fields",
 			content: `version: 1
 default_manager: cargo
@@ -48,9 +50,6 @@ ignore_patterns:
 				}
 				if cfg.OperationTimeout != 600 {
 					t.Errorf("Expected operation_timeout 600, got %d", cfg.OperationTimeout)
-				}
-				if cfg.PackageTimeout != 300 {
-					t.Errorf("Expected package_timeout 300, got %d", cfg.PackageTimeout)
 				}
 				if cfg.DotfileTimeout != 120 {
 					t.Errorf("Expected dotfile_timeout 120, got %d", cfg.DotfileTimeout)

--- a/internal/config/config_defaults_test.go
+++ b/internal/config/config_defaults_test.go
@@ -22,8 +22,7 @@ func TestApplyDefaults(t *testing.T) {
 			expected: &Config{
 				DefaultManager:    "brew",
 				OperationTimeout:  300, // 5 minutes
-				PackageTimeout:    180, // 3 minutes
-				DotfileTimeout:    60,  // 1 minute
+				DotfileTimeout:    60, // 1 minute
 				ExpandDirectories: []string{".config"},
 				IgnorePatterns:    defaultConfig.IgnorePatterns,
 			},
@@ -37,8 +36,7 @@ func TestApplyDefaults(t *testing.T) {
 			expected: &Config{
 				DefaultManager:    "npm",
 				OperationTimeout:  60,  // 1 minute
-				PackageTimeout:    180, // 3 minutes
-				DotfileTimeout:    60,  // 1 minute
+				DotfileTimeout:    60, // 1 minute
 				ExpandDirectories: []string{".config"},
 				IgnorePatterns:    defaultConfig.IgnorePatterns,
 			},
@@ -52,8 +50,7 @@ func TestApplyDefaults(t *testing.T) {
 			expected: &Config{
 				DefaultManager:    "brew",
 				OperationTimeout:  300, // 5 minutes
-				PackageTimeout:    180, // 3 minutes
-				DotfileTimeout:    60,  // 1 minute
+				DotfileTimeout:    60, // 1 minute
 				ExpandDirectories: []string{"custom-dir"},
 				IgnorePatterns:    []string{"custom.txt"},
 			},
@@ -62,17 +59,15 @@ func TestApplyDefaults(t *testing.T) {
 			name: "all values set preserves everything",
 			input: &Config{
 				DefaultManager:    "cargo",
-				OperationTimeout:  300,  // 5 minutes
-				PackageTimeout:    1200, // 20 minutes
-				DotfileTimeout:    60,   // 1 minute
+				OperationTimeout:  300, // 5 minutes
+				DotfileTimeout:    60,  // 1 minute
 				ExpandDirectories: []string{"my-config"},
 				IgnorePatterns:    []string{"*.bak"},
 			},
 			expected: &Config{
 				DefaultManager:    "cargo",
-				OperationTimeout:  300,  // 5 minutes
-				PackageTimeout:    1200, // 20 minutes
-				DotfileTimeout:    60,   // 1 minute
+				OperationTimeout:  300, // 5 minutes
+				DotfileTimeout:    60,  // 1 minute
 				ExpandDirectories: []string{"my-config"},
 				IgnorePatterns:    []string{"*.bak"},
 			},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,9 +28,6 @@ func TestLoad_MissingFile(t *testing.T) {
 	if cfg.OperationTimeout != 300 {
 		t.Errorf("Expected operation timeout 300, got %d", cfg.OperationTimeout)
 	}
-	if cfg.PackageTimeout != 180 {
-		t.Errorf("Expected package timeout 180, got %d", cfg.PackageTimeout)
-	}
 	if cfg.DotfileTimeout != 60 {
 		t.Errorf("Expected dotfile timeout 60, got %d", cfg.DotfileTimeout)
 	}
@@ -51,7 +48,6 @@ func TestLoad_ValidConfig(t *testing.T) {
 	configContent := `
 default_manager: brew
 operation_timeout: 600
-package_timeout: 300
 dotfile_timeout: 120
 expand_directories:
   - .vim
@@ -73,9 +69,6 @@ ignore_patterns:
 	}
 	if cfg.OperationTimeout != 600 {
 		t.Errorf("Expected operation timeout 600, got %d", cfg.OperationTimeout)
-	}
-	if cfg.PackageTimeout != 300 {
-		t.Errorf("Expected package timeout 300, got %d", cfg.PackageTimeout)
 	}
 	if cfg.DotfileTimeout != 120 {
 		t.Errorf("Expected dotfile timeout 120, got %d", cfg.DotfileTimeout)
@@ -114,9 +107,6 @@ operation_timeout: 400
 	}
 
 	// Check defaults for unspecified values
-	if cfg.PackageTimeout != 180 {
-		t.Errorf("Expected default package timeout 180, got %d", cfg.PackageTimeout)
-	}
 	if cfg.DotfileTimeout != 60 {
 		t.Errorf("Expected default dotfile timeout 60, got %d", cfg.DotfileTimeout)
 	}
@@ -198,12 +188,6 @@ operation_timeout: 3601
 `,
 		},
 		{
-			name: "package timeout too large",
-			content: `
-package_timeout: 1801
-`,
-		},
-		{
 			name: "dotfile timeout too large",
 			content: `
 dotfile_timeout: 601
@@ -266,7 +250,6 @@ func TestConfig_DirectFieldAccess(t *testing.T) {
 	cfg := &Config{
 		DefaultManager:    "npm",
 		OperationTimeout:  500,
-		PackageTimeout:    200,
 		DotfileTimeout:    100,
 		ExpandDirectories: []string{".config", ".vim"},
 		IgnorePatterns:    []string{"*.tmp", "*.log"},
@@ -278,9 +261,6 @@ func TestConfig_DirectFieldAccess(t *testing.T) {
 	}
 	if cfg.OperationTimeout != 500 {
 		t.Error("OperationTimeout returned wrong value")
-	}
-	if cfg.PackageTimeout != 200 {
-		t.Error("PackageTimeout returned wrong value")
 	}
 	if cfg.DotfileTimeout != 100 {
 		t.Error("DotfileTimeout returned wrong value")

--- a/internal/config/helpers_test.go
+++ b/internal/config/helpers_test.go
@@ -41,7 +41,6 @@ func TestGetDefaults(t *testing.T) {
 	assert.NotNil(t, defaults)
 	assert.Equal(t, "brew", defaults.DefaultManager)
 	assert.Equal(t, 300, defaults.OperationTimeout)
-	assert.Equal(t, 180, defaults.PackageTimeout)
 	assert.Equal(t, 60, defaults.DotfileTimeout)
 	assert.Contains(t, defaults.ExpandDirectories, ".config")
 	assert.Greater(t, len(defaults.IgnorePatterns), 0)
@@ -62,7 +61,6 @@ func TestValidateConfigFromYAML(t *testing.T) {
 		validYAML := []byte(`
 default_manager: brew
 operation_timeout: 300
-package_timeout: 180
 dotfile_timeout: 60
 `)
 		result := validator.ValidateConfigFromYAML(validYAML)

--- a/internal/config/timeouts.go
+++ b/internal/config/timeouts.go
@@ -8,7 +8,6 @@ import "time"
 // Timeouts provides typed duration values derived from Config timeouts (seconds)
 type Timeouts struct {
 	Operation time.Duration
-	Package   time.Duration
 	Dotfile   time.Duration
 }
 
@@ -18,13 +17,11 @@ func GetTimeouts(cfg *Config) Timeouts {
 		d := GetDefaults()
 		return Timeouts{
 			Operation: time.Duration(d.OperationTimeout) * time.Second,
-			Package:   time.Duration(d.PackageTimeout) * time.Second,
 			Dotfile:   time.Duration(d.DotfileTimeout) * time.Second,
 		}
 	}
 	return Timeouts{
 		Operation: time.Duration(cfg.OperationTimeout) * time.Second,
-		Package:   time.Duration(cfg.PackageTimeout) * time.Second,
 		Dotfile:   time.Duration(cfg.DotfileTimeout) * time.Second,
 	}
 }

--- a/internal/config/user_defined_test.go
+++ b/internal/config/user_defined_test.go
@@ -46,7 +46,7 @@ func TestIsFieldUserDefined(t *testing.T) {
 		assert.True(t, checker.IsFieldUserDefined("default_manager", "cargo"))
 		assert.True(t, checker.IsFieldUserDefined("operation_timeout", 600))
 		// Same as default, so not user-defined
-		assert.False(t, checker.IsFieldUserDefined("package_timeout", 180))
+		assert.False(t, checker.IsFieldUserDefined("dotfile_timeout", 60))
 	})
 
 	t.Run("with user config", func(t *testing.T) {
@@ -65,8 +65,8 @@ operation_timeout: 600
 		// 600 is different from default (300)
 		assert.True(t, checker.IsFieldUserDefined("operation_timeout", 600))
 
-		// 180 is same as default
-		assert.False(t, checker.IsFieldUserDefined("package_timeout", 180))
+		// 60 is same as default
+		assert.False(t, checker.IsFieldUserDefined("dotfile_timeout", 60))
 	})
 }
 
@@ -116,7 +116,6 @@ ignore_patterns:
 		assert.Contains(t, patterns, "custom_pattern")
 
 		// Should not contain defaults
-		assert.NotContains(t, nonDefaults, "package_timeout")
 		assert.NotContains(t, nonDefaults, "dotfile_timeout")
 	})
 
@@ -127,7 +126,6 @@ ignore_patterns:
 		cfg := &Config{
 			DefaultManager:    "brew",
 			OperationTimeout:  300,
-			PackageTimeout:    180,
 			DotfileTimeout:    60,
 			ExpandDirectories: []string{".config"},
 			IgnorePatterns:    checker.defaults.IgnorePatterns,
@@ -162,7 +160,6 @@ func TestGetDefaultFieldValue(t *testing.T) {
 	}{
 		{"default_manager", "brew"},
 		{"operation_timeout", 300},
-		{"package_timeout", 180},
 		{"dotfile_timeout", 60},
 		{"expand_directories", []string{".config"}},
 		{"diff_tool", ""},

--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -49,11 +49,12 @@ func (o *Orchestrator) Apply(ctx context.Context) (output.ApplyResult, error) {
 	// Derive per-domain timeouts
 	t := config.GetTimeouts(o.config)
 
-	// Apply packages (unless dotfiles-only)
+	// Apply packages (unless dotfiles-only).
+	// Per-package timeouts live inside packages.SimpleApply; we no longer wrap
+	// the whole batch in one budget — a single slow Homebrew download used to
+	// burn the entire phase's deadline.
 	if !o.dotfilesOnly {
-		pctx, pcancel := context.WithTimeout(ctx, t.Package)
-		simpleResult, err := packages.SimpleApply(pctx, o.configDir, o.dryRun)
-		pcancel()
+		simpleResult, err := packages.SimpleApply(ctx, o.configDir, o.dryRun)
 		if simpleResult != nil {
 			packageResult := convertSimpleApplyResult(simpleResult, o.dryRun)
 			result.Packages = &packageResult

--- a/internal/packages/apply.go
+++ b/internal/packages/apply.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/richhaase/plonk/internal/lock"
+	"github.com/richhaase/plonk/internal/output"
 )
 
 // SimpleApplyResult holds the result of applying packages
@@ -19,6 +21,10 @@ type SimpleApplyResult struct {
 	Failed       []string // Packages that failed to install
 	Errors       []error  // Errors for failed packages
 }
+
+// PerPackageTimeout bounds a single Install or IsInstalled invocation.
+// The orchestrator no longer caps the whole batch — each package gets its own budget.
+const PerPackageTimeout = 10 * time.Minute
 
 // SimpleApply installs all tracked packages that are missing
 func SimpleApply(ctx context.Context, configDir string, dryRun bool) (*SimpleApplyResult, error) {
@@ -39,12 +45,18 @@ func SimpleApply(ctx context.Context, configDir string, dryRun bool) (*SimpleApp
 	}
 	sort.Strings(managers)
 
-	// Process each manager in sorted order
+	// Phase 1: build install plan, recording skipped/would-install/failed-from-IsInstalled.
+	type planEntry struct {
+		spec string
+		pkg  string
+		mgr  Manager
+	}
+	var plan []planEntry
+
 	for _, manager := range managers {
 		pkgs := lockFile.Packages[manager]
 		mgr, err := GetManager(manager)
 		if err != nil {
-			// Record failure for each package individually
 			for _, pkg := range pkgs {
 				spec := manager + ":" + pkg
 				result.Failed = append(result.Failed, spec)
@@ -58,16 +70,15 @@ func SimpleApply(ctx context.Context, configDir string, dryRun bool) (*SimpleApp
 		for _, pkg := range pkgs {
 			spec := manager + ":" + pkg
 
-			// Short-circuit remaining packages if the manager itself is broken
-			// (e.g., binary not on PATH) to avoid repeated failing subprocesses.
 			if managerBroken {
 				result.Failed = append(result.Failed, spec)
 				result.Errors = append(result.Errors, fmt.Errorf("%s: %w", spec, managerErr))
 				continue
 			}
 
-			// Check if installed
-			installed, err := mgr.IsInstalled(ctx, pkg)
+			installed, err := callWithTimeout(ctx, func(c context.Context) (bool, error) {
+				return mgr.IsInstalled(c, pkg)
+			})
 			if err != nil {
 				managerBroken = true
 				managerErr = err
@@ -81,19 +92,31 @@ func SimpleApply(ctx context.Context, configDir string, dryRun bool) (*SimpleApp
 				continue
 			}
 
-			// Install (or mark as would-install for dry-run)
 			if dryRun {
 				result.WouldInstall = append(result.WouldInstall, spec)
 				continue
 			}
 
-			if err := mgr.Install(ctx, pkg); err != nil {
-				result.Failed = append(result.Failed, spec)
-				result.Errors = append(result.Errors, fmt.Errorf("%s: %w", spec, err))
+			plan = append(plan, planEntry{spec: spec, pkg: pkg, mgr: mgr})
+		}
+	}
+
+	// Phase 2: execute installs with live spinner feedback.
+	if len(plan) > 0 {
+		sm := output.NewSpinnerManager(len(plan))
+		for _, p := range plan {
+			spinner := sm.StartSpinner("Installing", p.spec)
+			err := callWithTimeoutVoid(ctx, func(c context.Context) error {
+				return p.mgr.Install(c, p.pkg)
+			})
+			if err != nil {
+				spinner.Error(fmt.Sprintf("%s: %s", p.spec, err.Error()))
+				result.Failed = append(result.Failed, p.spec)
+				result.Errors = append(result.Errors, fmt.Errorf("%s: %w", p.spec, err))
 				continue
 			}
-
-			result.Installed = append(result.Installed, spec)
+			spinner.Success(fmt.Sprintf("installed %s", p.spec))
+			result.Installed = append(result.Installed, p.spec)
 		}
 	}
 
@@ -103,4 +126,18 @@ func SimpleApply(ctx context.Context, configDir string, dryRun bool) (*SimpleApp
 	}
 
 	return result, nil
+}
+
+// callWithTimeout runs fn with a per-call timeout derived from PerPackageTimeout,
+// inheriting cancellation from the parent context.
+func callWithTimeout[T any](ctx context.Context, fn func(context.Context) (T, error)) (T, error) {
+	c, cancel := context.WithTimeout(ctx, PerPackageTimeout)
+	defer cancel()
+	return fn(c)
+}
+
+func callWithTimeoutVoid(ctx context.Context, fn func(context.Context) error) error {
+	c, cancel := context.WithTimeout(ctx, PerPackageTimeout)
+	defer cancel()
+	return fn(c)
 }


### PR DESCRIPTION
## Summary
- Render the apply result during `plonk clone` so the per-package breakdown is visible — previously only dotfile spinners streamed and the final error was a bare `N package(s) failed to install`.
- Wrap each `mgr.Install` call with `output.SpinnerManager.StartSpinner` so users see live `[N/M] Installing brew:xh` progress (matching the existing dotfile pattern).
- Replace the 180s batch `PackageTimeout` with a 10-minute per-package budget defined in `internal/packages/apply.go`. One slow Homebrew download can no longer poison the rest of the batch, so a fresh `plonk clone` on a populated lock file completes in one pass.
- Drop the now-unused `package_timeout` config field. Old configs that still set it keep loading because `yaml.Unmarshal` silently ignores unknown fields (covered by an existing compat test).

## Test plan
- [x] `make test` — Go unit tests
- [x] `make docker-test-all` — full BATS suite (116/116 passing)
- [ ] Manual: rerun the original failing flow on a clean Mac (`brew install richhaase/tap/plonk` → `plonk clone richhaase/dotfiles`) and confirm a single pass installs everything with live spinners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)