### PR TITLE
Fix BATS Homebrew trust in test image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,8 @@ ENV PATH="${HOME}/.bun/bin:${PATH}"
 # Install BATS support libraries via Homebrew
 RUN brew install bats-core && \
     brew tap bats-core/bats-core && \
+    brew trust --formula bats-core/bats-core/bats-support && \
+    brew trust --formula bats-core/bats-core/bats-assert && \
     brew install bats-support bats-assert
 
 # Create the bats library directories that test_helper.bash expects

--- a/docs/plans/2026-08-09-repair-bats-homebrew-assessment-verified.md
+++ b/docs/plans/2026-08-09-repair-bats-homebrew-assessment-verified.md
@@ -1,0 +1,69 @@
+---
+steward_assessment: "3"
+contract_path: "2026-08-09-repair-bats-homebrew-contract.md"
+contract_id: "repair-bats-homebrew-build"
+contract_revision: 1
+contract_body_sha256: "9d9440219a7e208a48969a603fbe403976938028c40ad218a862ddf71663d1de"
+change_identity: "sha256:4af136459259f47939d466a32d7ea60e8697b9ac647a4f1c9911f665eeeabfb3"
+environment: "macOS 26.5.2 host; Docker client 29.7.2; Docker Engine 29.4.0 linux/arm64; Homebrew 6.0.15 in image"
+assessor: "Codex"
+created_at: "2026-08-09T18:56:54.608Z"
+completed_at: "2026-08-09T18:57:22.852Z"
+state: completed
+assessment_body_sha256: "3f60f00ca98c7c6d8975377932c0e4a72a5ca331beebd1dd3ad1fed621201d13"
+---
+# Assessment: Repair BATS container build
+
+## Provenance
+
+- Immutable change: sha256:4af136459259f47939d466a32d7ea60e8697b9ac647a4f1c9911f665eeeabfb3
+- Environment/context: macOS 26.5.2 host; Docker client 29.7.2; Docker Engine 29.4.0 linux/arm64; Homebrew 6.0.15 in image
+- Assessor: Codex
+
+## Overall
+
+Outcome: pass
+
+## Claim outcomes
+
+### AC1: Building the project test container completes without the Homebrew untrusted-tap failure.
+- Outcome: pass
+- Evidence: E1
+- Residual uncertainty: The build was exercised on Linux arm64; GitHub's hosted integration runner is Linux amd64.
+
+### AC2: The built container provides BATS, bats-support, and bats-assert in the locations expected by the existing integration tests.
+- Outcome: pass
+- Evidence: E2
+- Residual uncertainty: None observed.
+
+### AC3: The container's existing integration-test entry point can execute the BATS suite.
+- Outcome: pass
+- Evidence: E3
+- Residual uncertainty: None observed.
+
+## Evidence log
+
+### E1
+- Command or artifact: `docker build --progress=plain -t plonk-test:latest .` against change `sha256:4af136459259f47939d466a32d7ea60e8697b9ac647a4f1c9911f665eeeabfb3`.
+- Observation: The command exited 0. Homebrew trusted only the two named formulae, installed bats-support 0.3.0 and bats-assert 2.2.4, completed all 21 image stages, and tagged `plonk-test:latest`.
+
+### E2
+- Command or artifact: `docker run --rm --entrypoint bash plonk-test:latest -lc 'set -e; command -v bats; readlink -f /usr/local/lib/bats-support; readlink -f /usr/local/lib/bats-assert; test -f /usr/local/lib/bats-support/load.bash; test -f /usr/local/lib/bats-assert/load.bash; echo BATS_LIBRARIES_OK'`.
+- Observation: The command exited 0, found BATS at `/home/linuxbrew/.linuxbrew/bin/bats`, resolved both `/usr/local/lib` links to installed Cellar directories, found both load files, and printed `BATS_LIBRARIES_OK`.
+
+### E3
+- Command or artifact: `docker run --rm plonk-test:latest all`.
+- Observation: The command exited 0, verified every configured package manager, and completed the existing BATS suite with all 116 tests passing, including the suite's intentional skips.
+
+## Contract observations
+
+- The formula-scoped repair preserves Homebrew's trust boundary; no whole-tap trust or global trust bypass is present.
+
+## Residual risks
+
+- GitHub Actions will rebuild on Linux amd64 rather than the locally verified Linux arm64 platform. The repaired commands and formulae are platform-independent within Homebrew's Linux support, but that runner was not directly sampled here.
+
+## Remediation
+
+Classification: none
+Next action: None.

--- a/docs/plans/2026-08-09-repair-bats-homebrew-assessment.md
+++ b/docs/plans/2026-08-09-repair-bats-homebrew-assessment.md
@@ -1,0 +1,75 @@
+---
+steward_assessment: "3"
+contract_path: "2026-08-09-repair-bats-homebrew-contract.md"
+contract_id: "repair-bats-homebrew-build"
+contract_revision: 1
+contract_body_sha256: "9d9440219a7e208a48969a603fbe403976938028c40ad218a862ddf71663d1de"
+change_identity: "sha256:4af136459259f47939d466a32d7ea60e8697b9ac647a4f1c9911f665eeeabfb3"
+environment: "macOS 26.5.2; Homebrew 6.0.15; Docker client 29.7.1; no Docker daemon available"
+assessor: "Codex"
+created_at: "2026-08-09T18:18:51.420Z"
+completed_at: "2026-08-09T18:19:39.799Z"
+state: completed
+assessment_body_sha256: "6e3f1c54a66bd43cecb9663b2852510c6a8d4c6eb922f6515ebfe2d85c209fb2"
+---
+# Assessment: Repair BATS container build
+
+## Provenance
+
+- Immutable change: sha256:4af136459259f47939d466a32d7ea60e8697b9ac647a4f1c9911f665eeeabfb3
+- Environment/context: macOS 26.5.2; Homebrew 6.0.15; Docker client 29.7.1; no Docker daemon available
+- Assessor: Codex
+
+## Overall
+
+Outcome: inconclusive
+
+## Claim outcomes
+
+### AC1: Building the project test container completes without the Homebrew untrusted-tap failure.
+- Outcome: inconclusive
+- Evidence: E1, E2, E3, E4
+- Residual uncertainty: The implementation directly addresses the observed trust failure with documented formula-scoped commands, but no Docker daemon was available to observe a complete image build.
+
+### AC2: The built container provides BATS, bats-support, and bats-assert in the locations expected by the existing integration tests.
+- Outcome: inconclusive
+- Evidence: E1, E4
+- Residual uncertainty: Static inspection shows that the existing installs and `/usr/local/lib` symlinks are preserved, but the resulting filesystem could not be observed without building the image.
+
+### AC3: The container's existing integration-test entry point can execute the BATS suite.
+- Outcome: inconclusive
+- Evidence: E1, E4
+- Residual uncertainty: The entry point and test command are unchanged, but container execution requires an available Docker daemon.
+
+## Evidence log
+
+### E1
+- Command or artifact: `git diff --binary -- Dockerfile | shasum -a 256`, producing the assessed change identity `sha256:4af136459259f47939d466a32d7ea60e8697b9ac647a4f1c9911f665eeeabfb3`.
+- Observation: The diff adds trust for only `bats-core/bats-core/bats-support` and `bats-core/bats-core/bats-assert`; the existing formula installation, support-library symlinks, and integration entry point are unchanged.
+
+### E2
+- Command or artifact: `brew help trust` using Homebrew 6.0.15.
+- Observation: The installed Homebrew exposes `brew trust --formula` for trusting named non-official formulae.
+
+### E3
+- Command or artifact: Homebrew Tap Trust documentation at `https://docs.brew.sh/Tap-Trust`.
+- Observation: Homebrew documents formula-scoped trust before short-name installation and recommends it over trusting an entire third-party tap.
+
+### E4
+- Command or artifact: `docker version` and `docker --context colima version`.
+- Observation: The Docker 29.7.1 client is installed, but both configured local contexts lack a running daemon socket, preventing image build and container execution.
+
+## Contract observations
+
+- The implementation preserves the contract's trust boundary: it neither trusts the whole BATS tap nor sets Homebrew's global trust opt-out.
+- `git diff --check` completed successfully.
+- The repository Go suite was exercised separately; all packages except two pre-existing non-TTY color-output tests passed. Those failures do not exercise the Dockerfile change or any acceptance claim.
+
+## Residual risks
+
+- Homebrew formula installation, the resulting symlink targets, and the BATS entry point remain unobserved in a built Linux container.
+
+## Remediation
+
+Classification: insufficient-or-conflicting-evidence
+Next action: With a Docker daemon available, run `docker build -t plonk-test:latest .`, verify both support-library symlink targets inside the image, and run `docker run --rm plonk-test:latest all`; then reassess this same frozen contract and immutable change unless the implementation changes.

--- a/docs/plans/2026-08-09-repair-bats-homebrew-contract.md
+++ b/docs/plans/2026-08-09-repair-bats-homebrew-contract.md
@@ -1,0 +1,37 @@
+---
+steward_contract: "3"
+id: "repair-bats-homebrew-build"
+title: "Repair BATS container build"
+revision: 1
+state: approved
+created_at: "2026-08-09T18:03:19.944Z"
+approved_at: "2026-08-09T18:16:00.962Z"
+approved_by: "rdh"
+frozen_body_sha256: "9d9440219a7e208a48969a603fbe403976938028c40ad218a862ddf71663d1de"
+supersedes: null
+---
+# Repair BATS container build
+
+## Outcome
+
+The project test container builds successfully and can run its existing BATS integration suite again.
+
+## Scope
+
+### Preserve
+
+- The existing BATS test entry point and support-library expectations remain compatible.
+
+### Not in scope
+
+- Unrelated dependency upgrades or CI workflow changes.
+
+## Acceptance
+
+- AC1: Building the project test container completes without the Homebrew untrusted-tap failure.
+- AC2: The built container provides BATS, bats-support, and bats-assert in the locations expected by the existing integration tests.
+- AC3: The container's existing integration-test entry point can execute the BATS suite.
+
+## Constraints
+
+- The repair must not globally disable or bypass package-source trust protections.


### PR DESCRIPTION
## Summary

- trust only the `bats-support` and `bats-assert` formulae from the BATS Homebrew tap
- preserve the existing BATS installation and `/usr/local/lib` compatibility links
- include the approved Steward contract and evidence-backed assessments

## Root cause

Homebrew 6 requires explicit trust for formulae loaded from non-official taps. The test-image build used short formula names without granting trust, so Homebrew refused to load `bats-support` and stopped before the integration suite could run.

## Impact

The integration-test image builds again without disabling Homebrew's trust protections or trusting the entire third-party tap.

## Validation

- `docker build --progress=plain -t plonk-test:latest .`
- verified both `/usr/local/lib/bats-support` and `/usr/local/lib/bats-assert` resolve to installed Homebrew Cellar paths and contain their load files
- `docker run --rm plonk-test:latest all` — all 116 BATS cases passed, including expected skips
- `git diff --check`
